### PR TITLE
Added options host, protocol, port, endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ list.members('bob@gmail.com').update({ name: 'Foo Bar' }, function (err, body) {
 * `mute` - Set to `true` if you wish to mute the console error logs in `validateWebhook()` function
 * `proxy` - The proxy URI in format `http[s]://[auth@]host:port`. ex: `'http://proxy.example.com:8080'`
 * `timeout` - Request timeout in milliseconds
+* `host` - the mailgun host (default: 'api.mailgun.net')
+* `protocol` - the mailgun protocol (default: 'https:', possible values: 'http:' or 'https:')
+* `port` - the mailgun port (default: '443')
+* `endpoint` - the mailgun host (default: '/v3')
 
 #### Attachments
 
@@ -196,7 +200,7 @@ Some examples:
 var domain = 'mydomain.mailgun.org';
 var mailgun = require('mailgun-js')({ apiKey: "YOUR API KEY", domain: domain });
 var mailcomposer = require('mailcomposer');
-    
+
 var mail = mailcomposer({
   from: 'you@samples.mailgun.org',
   to: 'mm@samples.mailgun.org',
@@ -216,7 +220,7 @@ mail.build(function(mailBuildError, message) {
         if (sendError) {
             console.log(sendError);
             return;
-        } 
+        }
     });
 });
 ```

--- a/lib/mailgun.js
+++ b/lib/mailgun.js
@@ -18,11 +18,20 @@ var Mailgun = function (options) {
   this.mute = options.mute || false;
   this.timeout = options.timeout;
 
+  this.host = options.host || 'api.mailgun.net';
+  this.endpoint = options.endpoint || '/v3';
+  this.protocol = options.protocol || 'https:';
+  this.port = options.port || 443;
+
   if (options.proxy) {
     this.proxy = options.proxy;
   }
 
   this.options = {
+    host: this.host,
+    endpoint: this.endpoint,
+    protocol: this.protocol,
+    port: this.port,
     auth: this.auth,
     proxy: this.proxy,
     timeout: this.timeout

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,4 +1,5 @@
 var https = require('https');
+var http = require('http');
 var proxy = require('proxy-agent');
 var qs = require('querystring');
 var q = require('q');
@@ -13,8 +14,10 @@ var noop = function () {
 };
 
 function Request(options) {
-  this.host = 'api.mailgun.net';
-  this.endpoint = '/v3';
+  this.host = options.host;
+  this.protocol = options.protocol;
+  this.port = options.port;
+  this.endpoint = options.endpoint;
   this.auth = options.auth;
   this.proxy = options.proxy;
   this.timeout = options.timeout;
@@ -69,6 +72,8 @@ Request.prototype.request = function (method, resource, data, fn) {
 
   var opts = {
     hostname: this.host,
+    port: this.port,
+    protocol: this.protocol,
     path: path,
     method: method,
     headers: this.headers,
@@ -248,8 +253,6 @@ Request.prototype.performRequest = function (options) {
   var method = options.method;
 
   if (this.form && (method === 'POST' || method === 'PUT' || method === 'PATCH')) {
-    options.port = 443;
-    options.protocol = 'https:';
 
     this.form.submit(options, function (err, res) {
       if (err) {
@@ -261,9 +264,17 @@ Request.prototype.performRequest = function (options) {
     });
   }
   else {
-    var req = https.request(options, function (res) {
-      return self.handleResponse(res);
-    });
+    var req;
+
+    if (options.protocol === 'http:') {
+      req = http.request(options, function (res) {
+        return self.handleResponse(res);
+      });
+    } else {
+      req = https.request(options, function (res) {
+        return self.handleResponse(res);
+      });
+    }
 
     if (options.timeout) {
       req.setTimeout(options.timeout, function () {


### PR DESCRIPTION
In order to install a mock mailgun server for test purpose, we have added host, protocol, port, and endpoint as options to the mailgun-js library. 

The default values remains the same. Here is the proposal pull request.

Thanks,