### PR TITLE
added ability to directly attach a stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,25 @@ mailgun.messages().send(data, function (error, body) {
 });
 ```
 
+We can also pass in a stream of the data. This is useful if you're attaching a file from the internet.
+
+```js
+var request = require('request');
+var file = request("https://www.google.ca/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png");
+
+var data = {
+  from: 'Excited User <me@samples.mailgun.org>',
+  to: 'serobnic@mail.ru',
+  subject: 'Hello',
+  text: 'Testing some Mailgun awesomness!',
+  attachment: file
+};
+
+mailgun.messages().send(data, function (error, body) {
+  console.log(body);
+});
+```
+
 Finally we provide a `Mailgun.Attachment` class to add attachments with a bit more customization. The Attachment
 constructor takes an `options` object. The `options` parameters can have the following fields:
 * `data` - can be one of

--- a/lib/request.js
+++ b/lib/request.js
@@ -175,6 +175,9 @@ Request.prototype.handleAttachmentObject = function (key, obj) {
   } else if (typeof obj === 'string') {
     debug('appending stream to form data. key: %s obj: %s', key, obj);
     this.form.append(key, fs.createReadStream(obj));
+  } else if ((typeof obj === 'object') && (obj.readable === true)) {
+    debug('appending readable stream to form data. key: %s obj: %s', key, obj);
+    this.form.append(key, obj);
   } else if ((typeof obj === 'object') && (obj instanceof Attachment)) {
     var attachmentType = obj.getType();
     if (attachmentType === 'path') {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "mailgun-js",
   "description": "Simple Node.js helper module for Mailgun API",
-  "keywords": ["email", "mailgun"],
+  "keywords": [
+    "email",
+    "mailgun"
+  ],
   "version": "0.7.6",
   "homepage": "https://github.com/1lobby/mailgun-js",
   "license": "MIT",
@@ -53,8 +56,9 @@
   ],
   "devDependencies": {
     "clone": "~1.0.0",
+    "mailcomposer": "~2.1.0",
     "mocha": "~2.3.4",
-    "mailcomposer": "~2.1.0"
+    "request": "^2.67.0"
   },
   "scripts": {
     "test": "mocha"

--- a/test/mailgun.test.js
+++ b/test/mailgun.test.js
@@ -5,6 +5,7 @@ var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
 var mailcomposer = require("mailcomposer");
+var request = require("request");
 
 var mailgun = require('../lib/mailgun')({apiKey: auth.api_key, domain: auth.domain});
 
@@ -296,6 +297,22 @@ module.exports = {
     msg.attachment = filename;
 
     msg['o:tag'] = ['tag1', 'tag2', 'tag3'];
+
+    mailgun.messages().send(msg, function (err, body) {
+      assert.ifError(err);
+      assert.ok(body.id);
+      assert.ok(body.message);
+      assert(/Queued. Thank you./.test(body.message));
+      done();
+    });
+  },
+  
+  'test messages().send() with attachment using stream': function (done) {
+    var msg = clone(fixture.message);
+
+    var file = request("https://www.google.ca/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png");
+
+    msg.attachment = file;
 
     mailgun.messages().send(msg, function (err, body) {
       assert.ifError(err);


### PR DESCRIPTION
This is helpful because you won't have to create an Attachment object for streams and figure out the contentType and knownLength. If you wanted to attach multiple files from the internet for example, you could very easily do this (using request module) by setting attachment: [request(url1), request(url2), request(url3), ...]